### PR TITLE
Changed the identifier from "model" to service; Also modified the get…

### DIFF
--- a/components/app/App.controller.js
+++ b/components/app/App.controller.js
@@ -175,7 +175,7 @@ function(
           button = this._getButtonForVisualisation(visualisationPluginDescriptor);
           var factory = this._getVisualisationFactory(visualisationPluginDescriptor);
           switch (factory.getScope()) {
-            case "model":
+            case "service":
               enabled = factory.canVisualiseModel(model);
               break;
             case "entityset":
@@ -211,14 +211,7 @@ function(
         if (entitySetName) {
           var jubilantMetaModel = this._getJubilantMetaModel();
           entitySetDescriptor = jubilantMetaModel.getEntitySetDescriptor(entitySetName);
-        }
-
-        switch (visualisationPluginDescriptor.factoryObject.getScope()){
-          case "entityset":
-            break;
-          case "model":
-            break;
-        }
+        }        
         
         var tabContainerItem = this._createTabContainerItem(visualisationPluginDescriptor, entitySetDescriptor);
         tabContainerItem.addContent(view);

--- a/components/visualisation/BaseVisualisationFactory.js
+++ b/components/visualisation/BaseVisualisationFactory.js
@@ -52,7 +52,18 @@ function(
     },
     getScope: function(){
       var visualisationPluginDescriptor = this._visualisationPluginDescriptor;
-      return visualisationPluginDescriptor.scope || "entityset";
+      var scope = visualisationPluginDescriptor.scope;
+      switch (scope) {
+        case undefined:
+          scope = "entityset";
+          break;
+        case "model":
+          scope = "service";
+          break;
+        default:
+          break;
+      }
+      return scope;
     },
     _createNewView: function(controller){
       var viewName = this._getViewName();

--- a/models/plugins.viz.json
+++ b/models/plugins.viz.json
@@ -1,7 +1,7 @@
 {"plugins": [
   {
     "name": "metadatagraph",
-    "scope": "model",
+    "scope": "service",
     "tooltip": "OData Metadata Graph",
     "description": "Graph of all OData entities and their relationships",
     "icon": "sap-icon://org-chart",


### PR DESCRIPTION
…Scope

method in the factory so that we preserve backwards compatibility and old
plugins with scope = "model" won't break and behave as if the scope is
"service".